### PR TITLE
Certificate multi-matcher

### DIFF
--- a/source/DSCResources/DSC_WSManListener/DSC_WSManListener.psm1
+++ b/source/DSCResources/DSC_WSManListener/DSC_WSManListener.psm1
@@ -627,7 +627,10 @@ function Find-Certificate
         $Hostname
     )
 
-    [System.String] $thumbprint = ''
+    $private:PSDefaultParameterValues = @{
+        'Get-Childitem:Path'                    = 'Cert:\LocalMachine\My'
+        'Get-ChildItem:SSLServerAuthentication' = $true
+    }
 
     if ($PSBoundParameters.ContainsKey('CertificateThumbprint'))
     {
@@ -637,7 +640,7 @@ function Find-Certificate
                     -f $CertificateThumbprint
             ) -join '' )
 
-        $certificate = Get-ChildItem -Path Cert:\localmachine\my | Where-Object -FilterScript {
+        $certificate = Get-ChildItem | Where-Object -FilterScript {
                 ($_.Thumbprint -eq $CertificateThumbprint)
             } | Select-Object -First 1
     }
@@ -667,9 +670,7 @@ function Find-Certificate
                             -f $Subject, $Issuer, $Hostname
                     ) -join '' )
 
-                $certificate = (Get-ChildItem -Path Cert:\localmachine\my | Where-Object -FilterScript {
-                        ($_.Extensions.EnhancedKeyUsages.FriendlyName `
-                                -contains 'Server Authentication') -and
+                $certificate = (Get-ChildItem | Where-Object -FilterScript {
                         ($_.Issuer -eq $Issuer) -and
                         ($Hostname -in $_.DNSNameList.Unicode) -and
                         ($_.Subject -eq $Subject)
@@ -684,9 +685,7 @@ function Find-Certificate
                             -f $Subject, $Issuer
                     ) -join '' )
 
-                $certificate = Get-ChildItem -Path Cert:\localmachine\my | Where-Object -FilterScript {
-                        ($_.Extensions.EnhancedKeyUsages.FriendlyName `
-                                -contains 'Server Authentication') -and
+                $certificate = Get-ChildItem | Where-Object -FilterScript {
                         ($_.Issuer -eq $Issuer) -and
                         ($_.Subject -eq $Subject)
                     } | Select-Object -First 1
@@ -714,9 +713,7 @@ function Find-Certificate
                             -f $Subject, $Issuer, $Hostname
                     ) -join '' )
 
-                $certificate = Get-ChildItem -Path Cert:\localmachine\my | Where-Object -FilterScript {
-                        ($_.Extensions.EnhancedKeyUsages.FriendlyName `
-                                -contains 'Server Authentication') -and
+                $certificate = Get-ChildItem | Where-Object -FilterScript {
                         ($_.Issuer -eq $Issuer) -and
                         ($Hostname -in $_.DNSNameList.Unicode) -and
                         ($_.Subject -eq $Subject)
@@ -731,9 +728,7 @@ function Find-Certificate
                             -f $Subject, $Issuer
                     ) -join '' )
 
-                $certificate = Get-ChildItem -Path Cert:\localmachine\my | Where-Object -FilterScript {
-                        ($_.Extensions.EnhancedKeyUsages.FriendlyName `
-                                -contains 'Server Authentication') -and
+                $certificate = Get-ChildItem | Where-Object -FilterScript {
                         ($_.Issuer -eq $Issuer) -and
                         ($_.Subject -eq $Subject)
                     } | Select-Object -First 1

--- a/source/DSCResources/DSC_WSManListener/DSC_WSManListener.psm1
+++ b/source/DSCResources/DSC_WSManListener/DSC_WSManListener.psm1
@@ -133,8 +133,8 @@ function Get-TargetResource
         Listener if a thumbprint is not specified.
 
     .PARAMETER DN
-        This is a Distinguished Name component that will be used to identify the certificate to use
-        for the HTTPS WS-Man Listener if a thumbprint is not specified.
+        This is the BaseDN (path part of the full Distinguished Name) used to identify the certificate
+        to use for the HTTPS WS-Man Listener if a thumbprint is not specified.
 
     .PARAMETER CertificateThumbprint
         The Thumbprint of the certificate to use for the HTTPS WS-Man Listener.
@@ -360,8 +360,8 @@ function Set-TargetResource
         Listener if a thumbprint is not specified.
 
     .PARAMETER DN
-        This is a Distinguished Name component that will be used to identify the certificate to use
-        for the HTTPS WS-Man Listener if a thumbprint is not specified.
+        This is the BaseDN (path part of the full Distinguished Name) used to identify the certificate
+        to use for the HTTPS WS-Man Listener if a thumbprint is not specified.
 
     .PARAMETER CertificateThumbprint
         The Thumbprint of the certificate to use for the HTTPS WS-Man Listener.
@@ -589,8 +589,8 @@ function Get-DefaultPort
         Listener if a thumbprint is not specified.
 
     .PARAMETER DN
-        This is a Distinguished Name component that will be used to identify the certificate to use
-        for the HTTPS WS-Man Listener if a thumbprint is not specified.
+        This is the BaseDN (path part of the full Distinguished Name) used to identify the certificate
+        to use for the HTTPS WS-Man Listener if a thumbprint is not specified.
 
     .PARAMETER CertificateThumbprint
         The Thumbprint of the certificate to use for the HTTPS WS-Man Listener.

--- a/source/DSCResources/DSC_WSManListener/DSC_WSManListener.schema.mof
+++ b/source/DSCResources/DSC_WSManListener/DSC_WSManListener.schema.mof
@@ -8,7 +8,7 @@ class DSC_WSManListener : OMI_BaseResource
     [Write, Description("The Issuer of the certificate to use for the HTTPS WS-Man Listener if a thumbprint is not specified.")] String Issuer;
     [Write, Description("The format used to match the certificate subject to use for an HTTPS WS-Man Listener if a thumbprint is not specified."), ValueMap{"Both","FQDNOnly","NameOnly"}, Values{"Both","FQDNOnly","NameOnly"}] String SubjectFormat;
     [Write, Description("Should the FQDN/Name be used to also match the certificate alternate subject for an HTTPS WS-Man Listener if a thumbprint is not specified.")] Boolean MatchAlternate;
-    [Write, Description("This is a Distinguished Name component that will be used to identify the certificate to use for the HTTPS WS-Man Listener if a thumbprint is not specified.")] String DN;
+    [Write, Description("This is the BaseDN (base of the full Distinguished Name) used to identify the certificate to use for the HTTPS WS-Man Listener if a thumbprint is not specified.")] String DN;
     [Write, Description("The host name that a HTTPS WS-Man Listener will be bound to. If not specified it will default to the computer name of the node.")] String Hostname;
     [Read, Description("Returns true if the existing WS-Man Listener is enabled.")] Boolean Enabled;
     [Read, Description("The URL Prefix of the existing WS-Man Listener.")] String URLPrefix;

--- a/tests/Integration/DSC_WSManListener.Integration.Tests.ps1
+++ b/tests/Integration/DSC_WSManListener.Integration.Tests.ps1
@@ -91,8 +91,8 @@ try
         Remove-Item -Force
 
     $Hostname = ([System.Net.Dns]::GetHostByName($ENV:computerName).Hostname)
-    $DN = 'O=Contoso Inc, S=Pennsylvania, C=US'
-    $Issuer = "CN=$Hostname, $DN"
+    $BaseDN = 'O=Contoso Inc, S=Pennsylvania, C=US'
+    $Issuer = "CN=$Hostname, $BaseDN"
 
     # Create the certificate
     if ([System.Environment]::OSVersion.Version.Major -ge 10)
@@ -146,7 +146,7 @@ try
                     Issuer         = $Issuer
                     SubjectFormat  = 'Both'
                     MatchAlternate = $False
-                    DN             = $DN
+                    BaseDN         = $BaseDN
                     Hostname       = $Hostname
                 }
             )

--- a/tests/Integration/DSC_WSManListener_Add_HTTPS.config.ps1
+++ b/tests/Integration/DSC_WSManListener_Add_HTTPS.config.ps1
@@ -10,7 +10,7 @@ Configuration DSC_WSManListener_Config_Add_HTTPS {
             Issuer         = $Node.Issuer
             SubjectFormat  = $Node.SubjectFormat
             MatchAlternate = $Node.MatchAlternate
-            DN             = $Node.DN
+            DN             = $Node.BaseDN
         }
     }
 }

--- a/tests/Unit/DSC_WSManListener.Tests.ps1
+++ b/tests/Unit/DSC_WSManListener.Tests.ps1
@@ -34,7 +34,7 @@ try
         $mockCertificateThumbprint = '74FA31ADEA7FDD5333CED10910BFA6F665A1F2FC'
         $mockHostName = $([System.Net.Dns]::GetHostByName($ENV:computerName).Hostname)
         $mockIssuer = 'CN=CONTOSO.COM Issuing CA, DC=CONTOSO, DC=COM'
-        $mockDN = 'O=Contoso Inc, S=Pennsylvania, C=US'
+        $mockBaseDN = 'O=Contoso Inc, S=Pennsylvania, C=US'
 
         $mockCertificate = [PSObject] @{
             Thumbprint = $mockCertificateThumbprint
@@ -44,9 +44,9 @@ try
             DNSNameList = @{ Unicode = $mockHostName }
         }
 
-        $mockCertificateDN = [PSObject] @{
+        $mockCertificateWithBaseDN = [PSObject] @{
             Thumbprint = $mockCertificateThumbprint
-            Subject = "CN=$mockHostName, $mockDN"
+            Subject = "CN=$mockHostName, $mockBaseDN"
             Issuer = $mockIssuer
             Extensions = @{ EnhancedKeyUsages = @{ FriendlyName = 'Server Authentication' } }
             DNSNameList = @{ Unicode = $mockHostName }
@@ -500,7 +500,7 @@ try
 
             Context 'CertificateThumbprint is passed and does exist' {
                 Mock -CommandName Get-ChildItem -MockWith {
-                    $mockCertificateDN
+                    $mockCertificateWithBaseDN
                 }
 
                 It 'Should not throw error' {
@@ -526,7 +526,7 @@ try
                         -Issuer $mockIssuer `
                         -SubjectFormat 'Both' `
                         -MatchAlternate $True `
-                        -DN $mockDN  `
+                        -DN $mockBaseDN  `
                         -Verbose } | Should -Not -Throw
                 }
 
@@ -541,7 +541,7 @@ try
 
             Context 'SubjectFormat is Both, Certificate with DN Exists, DN passed' {
                 Mock -CommandName Get-ChildItem -MockWith {
-                    $mockCertificateDN
+                    $mockCertificateWithBaseDN
                 }
 
                 It 'Should not throw error' {
@@ -549,7 +549,7 @@ try
                         -Issuer $mockIssuer `
                         -SubjectFormat 'Both' `
                         -MatchAlternate $True `
-                        -DN $mockDN  `
+                        -DN $mockBaseDN  `
                         -Verbose } | Should -Not -Throw
                 }
 
@@ -562,7 +562,7 @@ try
                 }
             }
 
-            Context 'SubjectFormat is Both, Certificate without DN Exists, DN passed' {
+            Context 'SubjectFormat is Both, Certificate without Base DN Exists, DN passed' {
                 Mock -CommandName Get-ChildItem -MockWith {
                     $mockCertificate
                 }
@@ -572,7 +572,7 @@ try
                         -Issuer $mockIssuer `
                         -SubjectFormat 'Both' `
                         -MatchAlternate $True `
-                        -DN $mockDN  `
+                        -DN $mockBaseDN  `
                         -Verbose } | Should -Not -Throw
                 }
 
@@ -605,9 +605,9 @@ try
                 }
             }
 
-            Context 'SubjectFormat is Both, Certificate with DN Exists, DN not passed' {
+            Context 'SubjectFormat is Both, Certificate with Base DN Exists, DN not passed' {
                 Mock -CommandName Get-ChildItem -MockWith {
-                    $mockCertificateDN
+                    $mockCertificateWithBaseDN
                 }
 
                 It 'Should not throw error' {
@@ -627,7 +627,7 @@ try
                 }
             }
 
-            Context 'SubjectFormat is Both, Certificate without DN Exists, DN not passed' {
+            Context 'SubjectFormat is Both, Certificate without Base DN Exists, DN not passed' {
                 Mock -CommandName Get-ChildItem -MockWith {
                     $mockCertificate
                 }


### PR DESCRIPTION
<!--
    Thanks for submitting a Pull Request (PR) to this project.
    Your contribution to this project is greatly appreciated!

    Please prefix the PR title with the resource name,
    e.g. 'ResourceName: My short description'.
    If this is a breaking change, then also prefix the PR title
    with 'BREAKING CHANGE:',
    e.g. 'BREAKING CHANGE: ResourceName: My short description'.

    You may remove this comment block, and the other comment blocks, but please
    keep the headers and the task list.
-->
#### Pull Request (PR) description

This PR makes it possible to set multiple values for `Issuer` and `DN` (makes them arrays).  Setting them as arrays allows a single configuration be used for a wider range of circumstances, such as multi-cloud environments where the issuer might be different in each.  To achieve this the `Find-Certificate` function has been overhauled from a series of `if-then-else` statements, to something more like a compiler for a `Where-Object` filter script block.  This reduces repetition and complexity, and should make it easier to add additional filter parameters.  In cases where multiple matching certificates exist, the final list is sorted based on the array input order to ensure determinism, and the first one is returned.

Care has been taken to ensure all existing tests pass, although some minor modifications were required to add new tests.  Several additional tests were added.

This PR also fixes #89 as a separate commit, although those changes have no functional effect.

Additional information in the commit comments.

#### This Pull Request (PR) fixes the following issues

- Fixes #89

#### Task list
<!--
    To aid community reviewers in reviewing and merging your PR, please take
    the time to run through the below checklist and make sure your PR has
    everything updated as required.

    Change to [x] for each task in the task list that applies to your PR.
    For those task that don't apply to you PR, leave those as is.
-->
- [ ] Added an entry to the change log under the Unreleased section of the
      file CHANGELOG.md. Entry should say what was changed and how that
      affects users (if applicable), and reference the issue being resolved
      (if applicable).
- [ ] Resource documentation added/updated in README.md.
- [ ] Resource parameter descriptions added/updated in README.md, schema.mof
      and comment-based help.
- [ ] Comment-based help added/updated.
- [ ] Localization strings added/updated in all localization files as appropriate.
- [ ] Examples appropriately added/updated.
- [x] Unit tests added/updated. See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guideline).
- [ ] Integration tests added/updated (where possible). See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guideline).
- [ ] New/changed code adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dsccommunity/wsmandsc/95)
<!-- Reviewable:end -->
