### PR TITLE
Add support for overwriting the hostname and/or certificate thumbprint on the listener - Fixes #23

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- WSManDsc
+  - Added support for changing the hostname and/or certificate thumbprint on the listener - fixes [Issue #23](https://github.com/dsccommunity/WSManDsc/issues/23).
+
 ### Added
 
 - Added build task `Generate_Conceptual_Help` to generate conceptual help

--- a/source/DSCResources/DSC_WSManListener/DSC_WSManListener.psm1
+++ b/source/DSCResources/DSC_WSManListener/DSC_WSManListener.psm1
@@ -462,6 +462,26 @@ function Test-TargetResource
                     ) -join '' )
                 $desiredConfigurationMatch = $false
             }
+
+            if ($PSBoundParameters.ContainsKey('Hostname') -and $listener.Hostname -ne $Hostname)
+            {
+                Write-Verbose -Message ( @(
+                        "$($MyInvocation.MyCommand): "
+                        $($script:localizedData.ListenerOnWrongHostnameMessage) `
+                            -f $Transport, $listener.Hostname, $Hostname
+                    ) -join '' )
+                $desiredConfigurationMatch = $false
+            }
+
+            if ($PSBoundParameters.ContainsKey('CertificateThumbprint') -and $listener.CertificateThumbprint -ne $CertificateThumbprint)
+            {
+                Write-Verbose -Message ( @(
+                        "$($MyInvocation.MyCommand): "
+                        $($script:localizedData.ListenerOnWrongCertificateThumbprintMessage) `
+                            -f $Transport, $listener.CertificateThumbprint, $CertificateThumbprint
+                    ) -join '' )
+                $desiredConfigurationMatch = $false
+            }
         }
         else
         {

--- a/source/DSCResources/DSC_WSManListener/en-US/DSC_WSManListener.strings.psd1
+++ b/source/DSCResources/DSC_WSManListener/en-US/DSC_WSManListener.strings.psd1
@@ -12,6 +12,8 @@ ConvertFrom-StringData @'
     TestingListenerMessage = Testing Listener.
     ListenerOnWrongPortMessage = {0} Listener is on port {1}, should be on {2}. Change required.
     ListenerOnWrongAddressMessage = {0} Listener is bound to {1}, should be {2}. Change required.
+    ListenerOnWrongHostnameMessage = {0} Listener Hostname is {1}, should be {2}. Change required.
+    ListenerOnWrongCertificateThumbprintMessage = {0} Listener Certificate Thumbprint is {1}, should be {2}. Change required.
     ListenerDoesNotExistButShouldMessage = {0} Listener does not exist but should. Change required.
     ListenerExistsButShouldNotMessage = {0} Listener exists but should not. Change required.
     ListenerDoesNotExistAndShouldNotMessage = {0} Listener does not exist and should not. Change not required.


### PR DESCRIPTION
#### Pull Request (PR) description

This PR adds support for overwriting the hostname and/or certificate thumbprint on an HTTPS listener if a listener already exists with a different hostname and/or certificate thumbprint.

#### This Pull Request (PR) fixes the following issues

- Fixes #23

#### Task list

- [x] Added an entry to the change log under the Unreleased section of the
      file CHANGELOG.md. Entry should say what was changed and how that
      affects users (if applicable), and reference the issue being resolved
      (if applicable).
- [ ] Resource documentation added/updated in README.md.
- [ ] Resource parameter descriptions added/updated in README.md, schema.mof
      and comment-based help.
- [ ] Comment-based help added/updated.
- [x] Localization strings added/updated in all localization files as appropriate.
- [ ] Examples appropriately added/updated.
- [ ] Unit tests added/updated. See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [ ] Integration tests added/updated (where possible). See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [x] New/changed code adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dsccommunity/WSManDsc/101)
<!-- Reviewable:end -->
